### PR TITLE
A tiny fix for the padding of the buttons with icons but no text

### DIFF
--- a/gh-buttons.css
+++ b/gh-buttons.css
@@ -38,6 +38,11 @@ http://github.com/necolas/css3-github-buttons
     *display: inline; 
 }
 
+/* overrides padding for buttons with icons but no text */
+.button.no-text {
+  padding-right: 0px !important;
+}
+
 .button:hover,
 .button:focus,
 .button:active,


### PR DESCRIPTION
This tiny line fixes the problem with buttons that have icons
but no text. In this case the padding-right is too wide.
