### PR TITLE
Now .button.danger.active buttons have white text instead of red.

### DIFF
--- a/gh-buttons.css
+++ b/gh-buttons.css
@@ -264,7 +264,8 @@
 
 .button.danger:hover,
 .button.danger:focus,
-.button.danger:active {
+.button.danger:active,
+.button.danger.active {
     border-color: #b53f3a;
     border-bottom-color: #a0302a;
     color: #fff;


### PR DESCRIPTION
Previously `<a href="#button" class="button active danger">Delete post</a>` would have `color: #900`, wich was obvously wrong. Now it has `color: #fff` 
